### PR TITLE
Correct "noticetype" parameter to "noticetypes" in docs

### DIFF
--- a/notice/notice-feed.md
+++ b/notice/notice-feed.md
@@ -97,7 +97,7 @@ In each instance the base URI can be either `/{service}/notice` or  `/{service}/
 ## Parameters ##
 <table>
 <tr>
-<td rowspan=2 style="width:12em">noticetype</td>
+<td rowspan=2 style="width:12em">noticetypes</td>
 <td>1 or more 4 digit notice code(s) separated by +. <a href="notice-taxonomy.md">Complete notice taxonomy</a>
 </td>
 </tr>


### PR DESCRIPTION
In the documentation, the parameter to get notices of a certain type seems to be misspelled, when testing it returns all notices, while "noticetypes" parameter returns notices of the correct type.